### PR TITLE
Add in config value for import_export profiles

### DIFF
--- a/app/code/community/Mage/Lite/etc/config.xml
+++ b/app/code/community/Mage/Lite/etc/config.xml
@@ -47,7 +47,7 @@
         </setup>
       </magelite_setup>
     </resources>
-    
+
   </global>
 
   <admin>
@@ -105,4 +105,22 @@
       </design>
     </admin>
   </stores>
+
+  <!-- set default folders for import/export -->
+  <!-- ref: http://magento.stackexchange.com/questions/71831/unable-to-save-or-run-import-export-dataflow-profiles-->
+    <default>
+        <general>
+            <file>
+                <importexport_local_valid_paths>
+                    <available>
+                        <export_xml>var/export/*/*.xml</export_xml>
+                        <export_csv>var/export/*/*.csv</export_csv>
+                        <import_xml>var/import/*/*.xml</import_xml>
+                        <import_csv>var/import/*/*.csv</import_csv>
+                    </available>
+                </importexport_local_valid_paths>
+                <bunch_size>100</bunch_size>
+            </file>
+        </general>
+    </default>
 </config>


### PR DESCRIPTION
When doing import via custom coded dataflow profiles, you get a profile exception:

```
2015-10-12T03:37:43+00:00 ERR (3):
exception 'Mage_Dataflow_Model_Convert_Exception' with message 'Please set available and/or protected paths list(s) before validation.' in /vagra
Stack trace:
#0 /vagrant/projects/lite/www/app/code/core/Mage/Dataflow/Model/Profile.php(205): Mage_Dataflow_Model_Convert_Profile_Abstract->run()
#1 /vagrant/projects/lite/www/app/code/local/Enjo/Consultant/Model/Cron.php(29): Mage_Dataflow_Model_Profile->run()
#2 /vagrant/projects/lite/www/app/code/local/Enjo/Consultant/Model/Cron.php(8): Enjo_Consultant_Model_Cron::runProfile('1')
#3 [internal function]: Enjo_Consultant_Model_Cron->importConsultants(Object(Aoe_Scheduler_Model_Schedule))
#4 /vagrant/projects/lite/www/app/code/community/Aoe/Scheduler/Model/Schedule.php(196): call_user_func_array(Array, Array)
#5 /vagrant/projects/lite/www/app/code/local/Enjo/Consultant/controllers/Adminhtml/Consultants/ImportController.php(38): Aoe_Scheduler_Model_Sche
#6 /vagrant/projects/lite/www/app/code/core/Mage/Core/Controller/Varien/Action.php(418): Enjo_Consultant_Adminhtml_Consultants_ImportController->
#7 /vagrant/projects/lite/www/app/code/core/Mage/Core/Controller/Varien/Router/Standard.php(250): Mage_Core_Controller_Varien_Action->dispatch('s
#8 /vagrant/projects/lite/www/app/code/core/Mage/Core/Controller/Varien/Front.php(172): Mage_Core_Controller_Varien_Router_Standard->match(Object
#9 /vagrant/projects/lite/www/app/code/core/Mage/Core/Model/App.php(354): Mage_Core_Controller_Varien_Front->dispatch()
#10 /vagrant/projects/lite/www/app/Mage.php(684): Mage_Core_Model_App->run(Array)
#11 /vagrant/projects/lite/www/index.php(87): Mage::run('', 'store')
#12 /vagrant/projects/lite/www/router.php(10): include_once('/vagrant/projec...')
#13 {main}
```

which is cased by missing config value located in ```general/file/importexport_local_valid_paths```
