### PR TITLE
add stub class Mage_Catalog_Model_Category to satisfy need for cache_tag

### DIFF
--- a/app/code/community/Mage/Catalog/Model/Category.php
+++ b/app/code/community/Mage/Catalog/Model/Category.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Satisfies Mage_Page_Block_Html_Topmenu::_construct needing CACHE_TAG
+ */
+class Mage_Catalog_Model_Category extends Mage_Core_Model_Abstract
+{
+    const CACHE_TAG = 'catalog_category';
+}


### PR DESCRIPTION
Mage_Page_Block_Html_Topmenu refers to const in non existing class 

$this->setCacheTags(array(Mage_Catalog_Model_Category::CACHE_TAG));